### PR TITLE
Fix: Crash When Parsing Fraction with Thousands Separators

### DIFF
--- a/Shared/Fraction.swift
+++ b/Shared/Fraction.swift
@@ -193,9 +193,11 @@ extension Fraction {
 				number = value.approximation.formatted(.number
 					.precision(.significantDigits(0..<5))
 				)
-				let reparsed = Fraction(number)!
-				if reparsed != value {
-					//print("fraction \(value) (\(decimal)) was imprecisely reparsed as \(reparsed)")
+				
+				// Remove thousands separators from the number
+				let cleanedNumber = number.filter { !Fraction.thousandsSeparators.contains($0) }
+				
+				if let reparsed = Fraction(cleanedNumber), reparsed != value {
 					let last = number.removeLast()
 					number.append(Self.underlines[last] ?? last)
 				}


### PR DESCRIPTION
This PR fixes a crash that occurs when parsing numbers with thousands separators (e.g., commas) back into Fraction objects inside the Fraction.Format struct. Specifically, the issue was causing a crash in format(_:) when re-parsing a formatted number with separators, leading to the fatal error:
`Thread 1: Fatal error: Unexpectedly found nil while unwrapping an Optional value`